### PR TITLE
Importación de componente IU en API

### DIFF
--- a/imports/api/menus.js
+++ b/imports/api/menus.js
@@ -3,8 +3,6 @@ import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Match } from 'meteor/check';
 import { Roles } from 'meteor/alanning:roles';
-import SimpleSchema from "simpl-schema";
-import Menu from "../ui/components/Menu";
 
 export const Menus = new Mongo.Collection("menus");
 


### PR DESCRIPTION
Dado que acá se tiene el manejo de base de datos, no deberían haber importaciones de un componente de la interfaz
, por otro lado  SimpleSchema es importado y no usado.